### PR TITLE
Add basic user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 
 1. Create your own .env file based on sample.env.
 2. Run using docker compose instead of running the Dockerfile or the go application directly
+
+## Creating an account
+
+Send a POST request to `/signup` with JSON body:
+
+```json
+{
+  "email": "you@example.com",
+  "password": "yourpassword"
+}
+```
+
+On success the server responds with HTTP 201.

--- a/backend/handlers/user_handlers.go
+++ b/backend/handlers/user_handlers.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"os"
+
+	"cloud.google.com/go/firestore"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/azezpz1/TeacherTools/models"
+)
+
+var (
+	ErrUserExists   = errors.New("user already exists")
+	ErrUserNotFound = errors.New("user not found")
+)
+
+// functions for database operations for easier testing
+var createUserInDB = func(ctx context.Context, client *firestore.Client, user models.User) error {
+	_, err := client.Collection("users").Doc(user.Email).Create(ctx, user)
+	if err != nil {
+		if status.Code(err) == codes.AlreadyExists {
+			return ErrUserExists
+		}
+		return err
+	}
+	return nil
+}
+
+var fetchUserByEmail = func(ctx context.Context, client *firestore.Client, email string) (models.User, error) {
+	doc, err := client.Collection("users").Doc(email).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return models.User{}, ErrUserNotFound
+		}
+		return models.User{}, err
+	}
+	var u models.User
+	if err := doc.DataTo(&u); err != nil {
+		return models.User{}, err
+	}
+	return u, nil
+}
+
+var signJWT = func(email string) (string, error) {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "dev_secret"
+	}
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(email))
+	mac.Write(b)
+	sum := mac.Sum(nil)
+	token := append(b, sum...)
+	return base64.StdEncoding.EncodeToString(token), nil
+}
+
+func CreateAccountHandler(client *firestore.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err := c.BindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+			return
+		}
+		if req.Email == "" || req.Password == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing email or password"})
+			return
+		}
+		hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := createUserInDB(context.Background(), client, models.User{Email: req.Email, PasswordHash: string(hashed)}); err != nil {
+			if err == ErrUserExists {
+				c.JSON(http.StatusConflict, gin.H{"error": "user already exists"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusCreated)
+	}
+}
+
+func LoginHandler(client *firestore.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err := c.BindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+			return
+		}
+		if req.Email == "" || req.Password == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing email or password"})
+			return
+		}
+		u, err := fetchUserByEmail(context.Background(), client, req.Email)
+		if err != nil {
+			if err == ErrUserNotFound {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(req.Password)); err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+			return
+		}
+		token, err := signJWT(req.Email)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"token": token})
+	}
+}
+
+func LogoutHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// For JWT based auth there is nothing to do server side
+		c.Status(http.StatusOK)
+	}
+}

--- a/backend/handlers/user_handlers_test.go
+++ b/backend/handlers/user_handlers_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/azezpz1/TeacherTools/models"
+)
+
+func setupUserRouter(client *firestore.Client) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/signup", CreateAccountHandler(client))
+	r.POST("/login", LoginHandler(client))
+	r.POST("/logout", LogoutHandler())
+	return r
+}
+
+func TestCreateAccountHandler_Success(t *testing.T) {
+	orig := createUserInDB
+	createUserInDB = func(ctx context.Context, client *firestore.Client, user models.User) error {
+		return nil
+	}
+	defer func() { createUserInDB = orig }()
+
+	r := setupUserRouter(nil)
+	body := `{"email":"a@test.com","password":"pass"}`
+	req, _ := http.NewRequest("POST", "/signup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected %d got %d", http.StatusCreated, w.Code)
+	}
+}
+
+func TestCreateAccountHandler_Conflict(t *testing.T) {
+	orig := createUserInDB
+	createUserInDB = func(ctx context.Context, client *firestore.Client, user models.User) error {
+		return ErrUserExists
+	}
+	defer func() { createUserInDB = orig }()
+
+	r := setupUserRouter(nil)
+	body := `{"email":"a@test.com","password":"pass"}`
+	req, _ := http.NewRequest("POST", "/signup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected %d got %d", http.StatusConflict, w.Code)
+	}
+}
+
+func TestLoginHandler_Success(t *testing.T) {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	origFetch := fetchUserByEmail
+	fetchUserByEmail = func(ctx context.Context, client *firestore.Client, email string) (models.User, error) {
+		return models.User{Email: email, PasswordHash: string(hashed)}, nil
+	}
+	origSign := signJWT
+	signJWT = func(email string) (string, error) { return "tok", nil }
+	defer func() { fetchUserByEmail = origFetch; signJWT = origSign }()
+
+	r := setupUserRouter(nil)
+	body := `{"email":"a@test.com","password":"pass"}`
+	req, _ := http.NewRequest("POST", "/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected %d got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestLoginHandler_Invalid(t *testing.T) {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	orig := fetchUserByEmail
+	fetchUserByEmail = func(ctx context.Context, client *firestore.Client, email string) (models.User, error) {
+		return models.User{Email: email, PasswordHash: string(hashed)}, nil
+	}
+	defer func() { fetchUserByEmail = orig }()
+
+	r := setupUserRouter(nil)
+	body := `{"email":"a@test.com","password":"wrong"}`
+	req, _ := http.NewRequest("POST", "/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected %d got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestLogoutHandler(t *testing.T) {
+	r := setupUserRouter(nil)
+	req, _ := http.NewRequest("POST", "/logout", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected %d got %d", http.StatusOK, w.Code)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -40,6 +40,10 @@ func main() {
 		})
 	})
 
+	r.POST("/signup", handlers.CreateAccountHandler(client))
+	r.POST("/login", handlers.LoginHandler(client))
+	r.POST("/logout", handlers.LogoutHandler())
+
 	r.GET("/student/teachers", handlers.GetTeachersForStudentHandler(client))
 
 	r.Run(":" + port)

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -1,0 +1,7 @@
+package models
+
+// User represents an application user.
+type User struct {
+	Email        string `firestore:"email" json:"email"`
+	PasswordHash string `firestore:"passwordHash" json:"-"`
+}


### PR DESCRIPTION
## Summary
- add user model and handlers for signup/login/logout
- wire up new endpoints
- document signup instructions in README
- test user management handlers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840f1804cf8832384f538e18f4ab81e